### PR TITLE
fixed init/mineos::stop

### DIFF
--- a/init/mineos
+++ b/init/mineos
@@ -45,7 +45,6 @@ case "$1" in
         if [ -s $PIDFILE ]; then
             log_begin_msg "Stopping $NAME..."
             kill -s INT `cat $PIDFILE` >/dev/null 2>&1
-            rm -- $PIDFILE
             RETVAL=$?
             log_action_end_msg $RETVAL
         else


### PR DESCRIPTION
Insserv takes care of removing the pidfile on a normal service stop. If the
service itself tries to remove the file, it is gone – resulting in the `stop`
action to “fail” with an exit status of 1.

Which in turn causes my chef recipe to fail on the service restart :)
