### PR TITLE
fix: display correct cumulative backup size on server status page

### DIFF
--- a/html/js/scriptin.js
+++ b/html/js/scriptin.js
@@ -263,7 +263,7 @@ function webui() {
 				try { return self.vmdata.increments()[self.vmdata.increments().length-1].timestamp } catch (e) { return 'None' }
 			}),
 			cumulative: ko.computed(function() {
-				try { return self.vmdata.increments()[0].cumulative_size } catch (e) { return '0 MB' }
+				try { return self.vmdata.increments()[self.vmdata.increments().length-1].cumulative_size } catch (e) { return '0 MB' }
 			})
 		},
 		archive: {


### PR DESCRIPTION
The server status page now correctly uses the oldest backup’s `cumulative_size`
instead of the newest.
