### PR TITLE
example WIP for #39 Jar File Upload

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -1226,7 +1226,7 @@ Is the information correct? [Y/n]
                     <!-- START Row -->
                     <div class="row-fluid">
                         <!-- START Form Wizard With Validation -->
-                        <form data-bind="submit: define_profile" class="span12 widget dark shadowed form-horizontal bordered" id="definenewprofile">
+                        <form data-bind="submit: define_profile" class="span12 widget dark shadowed form-horizontal bordered" id="definenewprofile" action="/test">
                             <header><h4 class="title">Create a New Server Profile</h4></header>
                             <section class="body">
                                 <div class="body-inner">
@@ -1260,6 +1260,12 @@ Is the information correct? [Y/n]
                                             <div class="controls">
                                                 <input type="text" name="save_as" class="input-xlarge" placeholder="craftbukkit.jar">
                                                 <span class="help-block">Be sure <em>only</em> the filename is here</span>
+                                            </div>
+                                        </div>
+                                        <div class="control-group" data-bind="visible: profile_type() == 'unmanaged'">
+                                            <label class="control-label">Upload Jar</label>
+                                            <div class="controls">
+                                                <input type="file" name="upload" class="input-xlarge">
                                             </div>
                                         </div>
                                         <div class="control-group">

--- a/html/js/scriptin.js
+++ b/html/js/scriptin.js
@@ -632,9 +632,18 @@ function webui() {
     }
 
 	self.define_profile = function(form) {
-		var step1 = $(form).find('fieldset :input').filter(function() {
+		var step1 = $(form).find('fieldset :input:not([type="file"])').filter(function() {
 			return ($(this).val() ? true : false);
 		})
+    
+    var file = $(form).find('input[name="upload"]')[0].files[0];
+    
+    var formData = new FormData();
+    formData.append('jar', file);
+    
+    var request = new XMLHttpRequest();
+    request.open("POST", "/test");
+    request.send(formData);
 
 		var properties = {};
 		$(step1).each(function() {

--- a/mounts.py
+++ b/mounts.py
@@ -215,7 +215,13 @@ class Root(object):
         return str(cherrypy.session['_cp_username'])
 
     @cherrypy.expose
-    @require()
+    def test(self, **raw_args):
+        import pdb
+        pdb.set_trace()
+        return str(raw_args['jar'].__class__.__name__)
+
+    @cherrypy.expose
+    #@require()
     def index(self):
         from cherrypy.lib.static import serve_file
         from cherrypy import NotFound


### PR DESCRIPTION
### RE: #39 Jar File Upload

@chibill
Assuming I understand the terminology correctly, "unmanaged" is the correct type for uploading your own jar, no?

As I said in issue #39, I'm not familiar with python, cherrypy nor knockout but have a ruby background with a great deal of JS experience, esp. angular so I'm managing. This is an example of how knockout can capture a file upload and send it to cherrypy (independent of the rest of the form _and in a POST like all of this data should be - btw, digressing_).

This commit sets up the `test` action to receive the file, which at present comes in as a cherrypy `Part` instance and needs to be written to the filesystem, I just don't know:
1.  How to write this object out to the FS
2.  Where to write it to

![screenshot 2014-02-10 01 55 06](https://f.cloud.github.com/assets/600733/2122977/620d9b9e-9220-11e3-94a2-db40384330ce.png)
