### PR TITLE
Update mineos.py

### DIFF
--- a/mineos.py
+++ b/mineos.py
@@ -1039,8 +1039,8 @@ class mc(object):
 
         self._previous_arguments = required_arguments
         return '%(screen)s -dmS %(screen_name)s ' \
-               '%(java)s -server %(java_debug)s -Xmx%(java_xmx)sM -Xms%(java_xms)sM %(java_tweaks)s ' \
-               '-jar %(jar_file)s %(jar_args)s' % required_arguments
+               '%(java)s %(java_debug)s %(jar_args)s -Xmx%(java_xmx)sM -Xms%(java_xms)sM %(java_tweaks)s ' \
+               '-jar %(jar_file)s -server' % required_arguments
 
     @property
     @sanitize


### PR DESCRIPTION
With original string cauldron server (MCPC+) can't start, because "-server" parameter sending to java, and "java_args" sending to jar-file.
P.S.: Sorry for my terrible english.
