### PR TITLE
Removing CSS IE hacks

### DIFF
--- a/html/css/icons/fontawesome/font-awesome.css
+++ b/html/css/icons/fontawesome/font-awesome.css
@@ -41,7 +41,7 @@
   font-style: normal;
   text-decoration: inherit;
   -webkit-font-smoothing: antialiased;
-  *margin-right: .3em;
+  margin-right: .3em;
 }
 [class^="icone-"]:before,
 [class*=" icone-"]:before {
@@ -267,12 +267,13 @@ a [class*=" icone-"] {
   width: 100%;
   height: 100%;
   font-size: 1em;
+  line-height: 2em;
   line-height: inherit;
-  *line-height: 2em;
 }
 .icone-stack .icone-stack-base {
   font-size: 2em;
-  *line-height: 1em;
+  line-height: 1em;
+  line-height: inherit;
 }
 /* Animated rotating icon */
 .icone-spin {


### PR DESCRIPTION
By moving switching the line-heights around I preform the desired affect. IE 7 and below will form the error when the reach inherit and will use the set amount. Other browsers will inherit as that was latter one declared.
