### PR TITLE
Left-over comment * or CSS Hack :: Invalid CSS

### DIFF
--- a/html/css/style.css
+++ b/html/css/style.css
@@ -1762,7 +1762,7 @@ ul.check li:last-child {
 #sidebar #nav > ul {
 	display: block;
 	margin: 0;
-	*zoom: 1;
+	zoom: 1;
 }
 #sidebar #nav > ul > li {
 	display: block;


### PR DESCRIPTION
While it is common CSS Hack to apply the property value in IE 7 and below it is not recommended. In this instance there is no change. Zoom: 1; most likely fixes an error in IE 7 and below, but it means zoom: 100% which is the default zoom value.
