### PR TITLE
Fix height of sidebar for iPhone running iOS7

### DIFF
--- a/html/css/style.css
+++ b/html/css/style.css
@@ -3354,6 +3354,8 @@ ul.check li:last-child {
 	.boxed-layout #sidebar,
 	.nav-open .boxed-layout #sidebar,
 	.boxed-layout #sidebar:before { left: 0; }
+	#sidebar #nav > ul > li > a > .text,
+        #sidebar #nav > ul > li > a > .icon { margin-top: 5px; margin-bottom: 5px; }
 
 	/* Main Content
 	------------------------------------------------------------------------- */


### PR DESCRIPTION
Height of sidebar items made bottom items inaccessible on iPhones running iOS7 (attempting to tap "Console" would bring up the iOS bottom bar). Adjusted margin on smaller screens to fix this issue.
