### PR TITLE
backup on shutdown, for ramdisk usage

### DIFF
--- a/html/index_en.html
+++ b/html/index_en.html
@@ -1117,6 +1117,7 @@ Is the information correct? [Y/n]
                                             <div class="controls">
                                                 <label class="checkbox">
                                                     <input data-section="onreboot" type="checkbox" name="start" value="true">
+                                                    <input data-section="onstop" type="checkbox" name="backup" value="false">
                                                 </label>
                                             </div>
                                         </div>

--- a/html/js/scriptin.js
+++ b/html/js/scriptin.js
@@ -52,6 +52,7 @@ function model_property(server_name, option, value, section, new_prop) {
 				{section: 'java', option: 'java_debug', type: 'truefalse'},
 				{section: 'onreboot', option: 'restore', type: 'truefalse'},
 				{section: 'onreboot', option: 'start', type: 'truefalse'},
+				{section: 'onstop', option: 'backup', type: 'truefalse'},
 				{section: 'crontabs', option: 'archive_interval', type: 'interval'},
 				{section: 'crontabs', option: 'backup_interval', type: 'interval'},
 				{section: 'crontabs', option: 'restart_interval', type: 'interval'}

--- a/mineos.py
+++ b/mineos.py
@@ -195,7 +195,8 @@ class mc(object):
             new_config = defaultdict(dict)
             kept_attributes = {
                 'onreboot': ['restore', 'start'],
-                'java': ['java_tweaks', 'java_xmx', 'java_xms']
+                'java': ['java_tweaks', 'java_xmx', 'java_xms'],
+                'onstop': ['backup']
                 }
 
             for section in kept_attributes:
@@ -278,6 +279,9 @@ class mc(object):
                 'java_xmx': 256,
                 'java_xms': 256,
                 'java_debug': False
+                },
+            'onstop': {
+                'backup': False
                 }
             }
 
@@ -374,6 +378,8 @@ class mc(object):
             self._command_stuff('end')
         else:
             self._command_stuff('stop')
+            if self.server_config.getboolean('onstop', 'backup'):
+                self._command_direct(self.command_backup, self.env['cwd'])
 
     @server_exists(True)
     def archive(self):

--- a/mineos_console.py
+++ b/mineos_console.py
@@ -129,7 +129,8 @@ if __name__=="__main__":
                         srv_ = i.server_name
                         owner = path_owner(os.path.join(i.base_dir, mc.DEFAULT_PATHS['servers'], srv_))
                         print "sending '%s' to %s..." % (args.cmd, srv_),
-                        instance = mc(srv_, owner, i.base_dir)._command_stuff(args.cmd)
+                        instance = mc(srv_, owner, i.base_dir).stop()
+                        #instance = mc(srv_, owner, i.base_dir)._command_stuff(args.cmd)
                         print ' done'
                     except Exception as ex:
                         print ex.message               


### PR DESCRIPTION
Added some bits and a config flag that lets you back up the server at shutdown so all the data can be pushed to disk from ram when using tmpfs or ramdisk. The alternative is to stop your MC world manually, then back it up, then restart the machine. Too many places to forget, too many ways to lose your latest game state for no good reason.

I'm not sure the web side is clean or how it should be; it found the setting in my config file, but didn't display it as a check box. I've not tested the "create new server" stuff, so I don't know if the changes I made affect that, either.
