### PR TITLE
Group perms

### DIFF
--- a/mineos.py
+++ b/mineos.py
@@ -709,7 +709,7 @@ class mc(object):
                                                                   self.screen_pid,
                                                                   stuff_text)
         check_call(split(command),
-                   preexec_fn=self._demote(self.owner.pw_uid, self.owner.pw_gid))
+                   preexec_fn=self._demote(self.owner.pw_uid, self.owner_gid))
 
 #validation checks
 
@@ -760,6 +760,11 @@ class mc(object):
         """Returns pwd named tuple"""
         from pwd import getpwnam
         return getpwnam(self._owner)
+
+    @property
+    def owner_gid(self):
+        """Returns grp named tuple"""
+        return os.stat(self.env['cwd']).st_gid)
 
     @property
     def up(self):

--- a/mineos.py
+++ b/mineos.py
@@ -694,7 +694,7 @@ class mc(object):
         return check_output(split(command),
                             cwd=working_directory,
                             stderr=STDOUT,
-                            preexec_fn=self._demote(self.owner.pw_uid, self.owner.pw_gid))
+                            preexec_fn=self._demote(self.owner.pw_uid, self.owner_gid))
 
     @server_exists(True)
     @server_up(True)
@@ -764,7 +764,7 @@ class mc(object):
     @property
     def owner_gid(self):
         """Returns grp named tuple"""
-        return os.stat(self.env['cwd']).st_gid)
+        return os.stat(self.env['cwd']).st_gid
 
     @property
     def up(self):

--- a/procfs_reader.py
+++ b/procfs_reader.py
@@ -52,6 +52,12 @@ def path_owner(path):
     uid = st.st_uid
     return getpwuid(uid).pw_name
 
+def path_group_owner(path):
+    from grp import getgrgid
+    st = os.stat(path)
+    gid = st.st_gid
+    return getgrgid(gid).gr_name
+
 def pid_owner(pid):
     from pwd import getpwuid
     


### PR DESCRIPTION
corrects an issue where started child processes would have the primary gid of the user rather than the gid that the user designates in the web-ui.  this does not solve a continuing issue where rdiff-backup creates backups with user perms, but lacking group and (other) perms.  This means that while backups can still be created, they will not see increment information.